### PR TITLE
Fix https://www.cloudping.info/ link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ to improve accuracy and as hardware improves.
 | Network NA West <-> Singapore       | 180 ms      | 25 MiB/s   | 40 ms  | 40s    |
 | Network EU West <-> Singapore       | 160 ms      | 25 MiB/s   | 40 ms  | 40s    |
 
-[i]: https://www.cloudping.co/grid#
+[i]: https://www.cloudping.info/ 
 
 **†:** "Fast serialization/deserialization" is typically a simple wire-protocol
 that just dumps bytes, or a very efficient environment. Typically standard

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ to improve accuracy and as hardware improves.
 | Network NA West <-> Singapore       | 180 ms      | 25 MiB/s   | 40 ms  | 40s    |
 | Network EU West <-> Singapore       | 160 ms      | 25 MiB/s   | 40 ms  | 40s    |
 
-[i]: https://www.cloudping.info/ 
+[i]: https://www.cloudping.co/ 
 
 **†:** "Fast serialization/deserialization" is typically a simple wire-protocol
 that just dumps bytes, or a very efficient environment. Typically standard


### PR DESCRIPTION
The current URL 404s. I believe this is the intended URL.
